### PR TITLE
Commit hash arg

### DIFF
--- a/commands/update.py
+++ b/commands/update.py
@@ -61,7 +61,7 @@ def do_update(args):
             url = urlutil.get_s3_url(s3_path)
             new_version = args.commit_hash
         else:
-            print("")
+            logging.critical(" we didn't find any firmware links with commit hash '{}'".format(args.commit_hash))
 
     if perform_update:
         # Do upgrade

--- a/commands/update.py
+++ b/commands/update.py
@@ -54,7 +54,8 @@ def do_update(args):
         url = board.get_download_url(new_version, board_id, 'uf2', args.locale)
 
     if args.commit_hash is not None:
-        s3_path = urlutil.find_firmware_by_hash(args.commit_hash, board_id, args.locale)
+        from s3util import find_firmware_by_hash
+        s3_path = find_firmware_by_hash(args.commit_hash, board_id, args.locale)
         if s3_path:
             perform_update = True
             url = urlutil.get_s3_url(s3_path)

--- a/commands/update.py
+++ b/commands/update.py
@@ -58,6 +58,7 @@ def do_update(args):
         if s3_path:
             perform_update = True
             url = urlutil.get_s3_url(s3_path)
+            new_version = args.commit_hash
         else:
             print("")
 
@@ -87,7 +88,7 @@ def do_update(args):
             logging.info("Waiting a bit for things to settle")
             time.sleep(9)
             (version, board_id) = board.identify(args.root)
-            if version == new_version:
+            if version == new_version or (args.commit_hash and new_version in version[-10:]):
                 logging.info("I checked the current version and it looks right! All updated.")
             else:
                 logging.error("I tried to update, and I expected the current version to be %s and instead it is %s" % (new_version, version))

--- a/commands/update.py
+++ b/commands/update.py
@@ -94,4 +94,5 @@ def setup_argument_parser(parser):
     parser.add_argument("--board", action="store", dest="board", help="specify the board type")
     parser.add_argument("--port", action="store", dest="port", default = port, help="the port for CircuitPython (default: %(default)s)", required=(port is None))
     parser.add_argument("--firmware-version", action="store", dest="firmware_version", help="the exact version you would like")
+    parser.add_argument("--commit-hash", action="store", dest="commit_hash", help="the commit hash of the build you would like")
     parser.set_defaults(func=do_update)

--- a/commands/update.py
+++ b/commands/update.py
@@ -45,16 +45,26 @@ def do_update(args):
         logging.info("The latest available version is %s and you have version %s" % (new_version, version))
         logging.debug("comparing %s to %s", version, new_version)
         perform_update = (semver.compare(version, new_version) < 0)
+        url = board.get_download_url(new_version, board_id, 'uf2', args.locale)
     else:
         # Forcing an update to a particular version
 
         new_version = args.firmware_version
         perform_update = True
+        url = board.get_download_url(new_version, board_id, 'uf2', args.locale)
+
+    if args.commit_hash is not None:
+        s3_path = urlutil.find_firmware_by_hash(args.commit_hash, board_id, args.locale)
+        if s3_path:
+            perform_update = True
+            url = urlutil.get_s3_url(s3_path)
+        else:
+            print("")
 
     if perform_update:
         # Do upgrade
         # Download UF2
-        url = board.get_download_url(new_version, board_id, 'uf2', args.locale)
+
         logging.debug("Final url is %s" % url)
         logging.info("Retrieving firmware from %s" % url)
         pathname = urlutil.get_local_file_from_url(url, args.tempdir)

--- a/commands/update.py
+++ b/commands/update.py
@@ -88,7 +88,7 @@ def do_update(args):
             logging.info("Waiting a bit for things to settle")
             time.sleep(9)
             (version, board_id) = board.identify(args.root)
-            if version == new_version or (args.commit_hash and new_version in version[-10:]):
+            if new_version in version:
                 logging.info("I checked the current version and it looks right! All updated.")
             else:
                 logging.error("I tried to update, and I expected the current version to be %s and instead it is %s" % (new_version, version))

--- a/s3util.py
+++ b/s3util.py
@@ -8,7 +8,7 @@ emojis = {
     logging.DEBUG       : "\N{Nerd Face}",
     logging.INFO        : "\N{Thumbs Up Sign}",
     logging.WARNING     : "\N{Worried Face}",
-    logging.ERROR       : "\N{No Entry}",
+    logging.ERROR       : "\N{Pouting Face}",
     logging.CRITICAL    : "\N{Serious Face With Symbols Covering Mouth}",
 }
 
@@ -19,7 +19,7 @@ try:
     import boto3
     from botocore.handlers import disable_signing
 except ImportError:
-    logging.error(" --commit-hash param will not work without boto3")
+    logging.critical(" --commit-hash param will not work without boto3")
 def find_firmware_by_hash(hash, board, language):
     resource = boto3.resource('s3')
     resource.meta.client.meta.events.register('choose-signer.s3.*', disable_signing)

--- a/s3util.py
+++ b/s3util.py
@@ -1,0 +1,31 @@
+import logging
+# Do some initial logging setup -- this really needs to be here, before you do
+# stuff with argparse. Trust me on this.
+logging.basicConfig(format="%(levelname)s %(message)s", level=logging.INFO)
+
+# Put in some emojis for fun
+emojis = {
+    logging.DEBUG       : "\N{Nerd Face}",
+    logging.INFO        : "\N{Thumbs Up Sign}",
+    logging.WARNING     : "\N{Worried Face}",
+    logging.ERROR       : "\N{No Entry}",
+    logging.CRITICAL    : "\N{Serious Face With Symbols Covering Mouth}",
+}
+
+for emoji in emojis:
+    logging.addLevelName(emoji, emojis[emoji])
+
+try:
+    import boto3
+    from botocore.handlers import disable_signing
+except ImportError:
+    logging.error(" --commit-hash param will not work without boto3")
+def find_firmware_by_hash(hash, board, language):
+    resource = boto3.resource('s3')
+    resource.meta.client.meta.events.register('choose-signer.s3.*', disable_signing)
+    bucket = resource.Bucket('adafruit-circuit-python')
+
+    for item in bucket.objects.filter(Prefix="bin/{}/{}/".format(board, language)):
+        if hash in item.key and ".uf2" in item.key:
+            return item.key
+    return None

--- a/urlutil.py
+++ b/urlutil.py
@@ -3,11 +3,6 @@ import logging
 import os.path
 import urllib.request
 from urllib.parse import urlparse
-try:
-    import boto3
-    from botocore.handlers import disable_signing
-except ImportError:
-    logging.warn("commit hash param will not work without boto3")
 
 def get_json_from_url(url):
     with urllib.request.urlopen(url) as stream:
@@ -31,16 +26,6 @@ def get_local_file_from_url(url, tempdir):
             output.write(stream.read())
 
     return pathname
-
-def find_firmware_by_hash(hash, board, language):
-    resource = boto3.resource('s3')
-    resource.meta.client.meta.events.register('choose-signer.s3.*', disable_signing)
-    bucket = resource.Bucket('adafruit-circuit-python')
-
-    for item in bucket.objects.filter(Prefix="bin/{}/{}/".format(board, language)):
-        if hash in item.key and ".uf2" in item.key:
-            return item.key
-    return None
 
 
 def get_s3_url(s3_path):

--- a/urlutil.py
+++ b/urlutil.py
@@ -3,6 +3,11 @@ import logging
 import os.path
 import urllib.request
 from urllib.parse import urlparse
+try:
+    import boto3
+    from botocore.handlers import disable_signing
+except ImportError:
+    logging.warn("commit hash param will not work without boto3")
 
 def get_json_from_url(url):
     with urllib.request.urlopen(url) as stream:
@@ -26,3 +31,18 @@ def get_local_file_from_url(url, tempdir):
             output.write(stream.read())
 
     return pathname
+
+def find_firmware_by_hash(hash, board, language):
+    resource = boto3.resource('s3')
+    resource.meta.client.meta.events.register('choose-signer.s3.*', disable_signing)
+    bucket = resource.Bucket('adafruit-circuit-python')
+
+    for item in bucket.objects.filter(Prefix="bin/{}/{}/".format(board, language)):
+        if hash in item.key and ".uf2" in item.key:
+            return item.key
+    return None
+
+
+def get_s3_url(s3_path):
+    BASE_URL = 'https://adafruit-circuit-python.s3.amazonaws.com/{}'
+    return BASE_URL.format(s3_path)


### PR DESCRIPTION
This adds `--commit-hash` parameter to the update command. It lets you specify a specific commit hash from a build hosted in S3. ex. `python blinka.py update --commit-hash bd87201`

There are still a few things that need to be addressed before this gets merged. Mainly that the post update check is checking version only and thinking that the update failed.

I wanted to go ahead and create this PR to see if you had any thoughts or feedback about this functionality or implementation @bcr 

It uses `boto3` to search the s3 files. I made it a soft requirement by catching the import error. I intend to catch the error in the command and let the user know they must have `boto3` in order to use this flag of the update command. Does that seem like a reasonable approach to you?