### PR TITLE
Make find_expected_volume return None on error

### DIFF
--- a/fsutil.py
+++ b/fsutil.py
@@ -37,10 +37,13 @@ def find_expected_volume(expected_volume_names, win=use_windows_api):
             if volume_name in expected_volume_names:
                 return drive
     else:
-        for drive in os.listdir("/media/{}".format(getpass.getuser())):
-            logging.debug("volume name is %s" % drive)
-            if drive in expected_volume_names:
-                return "/media/{}/{}".format(getpass.getuser(), drive)
+        try:
+            for drive in os.listdir("/media/{}".format(getpass.getuser())):
+                logging.debug("volume name is %s" % drive)
+                if drive in expected_volume_names:
+                    return "/media/{}/{}".format(getpass.getuser(), drive)
+        except:
+            return None
 
     logging.debug("did not find a suitable drive")
     return None

--- a/fsutil.py
+++ b/fsutil.py
@@ -43,7 +43,7 @@ def find_expected_volume(expected_volume_names, win=use_windows_api):
                 if drive in expected_volume_names:
                     return "/media/{}/{}".format(getpass.getuser(), drive)
         except:
-            return None
+            pass
 
     logging.debug("did not find a suitable drive")
     return None


### PR DESCRIPTION
I have a Pop_OS! machine now, I will do some more Linux testing going forward.

When trying to find the root on Linux it throws an exception if the media directory isn't found. I just made it so it eats the error and returns `None`