### PR TITLE
MagTag fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,15 @@ name / numberspaces:
 * Board IDs (firmware root names)
   * feather_m0_rfm69
   * pyportal_titano
+  * adafruit_magtag_2.9_grayscale
+* Board-ID from bootloader INFO_UF2.TXT
+  * MagTag-29gray-revC (different than board ID adafruit_magtag_2.9_grayscale in firmware root name)
 * USB VID / PID
   * Adafruit VID
   * PIDs differ between bootloader and user mode COM ports
 * Mounted disk volume labels
   * CIRCUITPY for user mode
+    * Can be renamed by user, so not reliable
   * LOTS for bootloader mode
     * `BOOT` is used a lot for a suffix
     * `shIRtty` mixed case, no `BOOT`
@@ -73,7 +77,6 @@ name / numberspaces:
     * `Grove Zero` mixed case, space in name, no `BOOT`
 * `os.uname()` information
   * `(sysname='samd51', nodename='samd51', release='6.0.0', version='6.0.0 on 2020-11-16', machine='Adafruit PyPortal Titano with samd51j20')`
-
 
 Some problems I have encountered:
 

--- a/blinka/board.py
+++ b/blinka/board.py
@@ -27,7 +27,7 @@ def identify(root):
 
     version = re.search(r"\s+(\d\S+)", parts[0]).group(1)
 
-    return (version, boards[boot_board])
+    return (version, boards.get(boot_board))
 
 def get_version_metadata(board_id):
     # This file has the metadata for all the boards. Go get it and find our board in it.

--- a/blinka/board_id_map.json
+++ b/blinka/board_id_map.json
@@ -1,4 +1,5 @@
 {
+  "MagTag with ESP32S2" : "adafruit_magtag_2.9_grayscale",
   "Adafruit Feather M0 RFM69 with samd21g18": "feather_m0_rfm69",
   "Adafruit PyPortal Titano with samd51j20": "pyportal_titano",
   "Adafruit Feather M4 CAN with same51j19a": "feather_m4_can",

--- a/blinka/commands/update.py
+++ b/blinka/commands/update.py
@@ -45,9 +45,9 @@ def do_update(args):
         try:
             target_firmware = next(version for version in metadata['versions'] if ('uf2' in version['extensions']) and (args.locale in version['languages']) and (args.stable == version['stable']))
         except:
-            message = "Could not find a stable firmware for %s %s." % (board_id, args.locale)
+            message = "Could not find %s firmware for %s %s." % ("a stable" if args.stable else "an unstable", board_id, args.locale)
             logging.critical(message)
-            logging.info("You can try the --unstable option and that might help.")
+            logging.info("You can try {}the --unstable option and that might help.".format("omitting " if not args.stable else ""))
             raise UpdateError(message)
         new_version = target_firmware['version']
         logging.debug("target_firmware %s" % target_firmware)

--- a/blinka/commands/update.py
+++ b/blinka/commands/update.py
@@ -39,6 +39,11 @@ def do_update(args):
     logging.debug("board_id = %s" % board_id)
     logging.debug("Current CircuitPython version is %s" % version)
 
+    if not board_id:
+        message = "Could not automatically determine your board type, use the --board option"
+        logging.critical(message)
+        raise UpdateError(message)
+
     if args.firmware_version is None:
         metadata = blinka.board.get_version_metadata(board_id)
         logging.debug("metadata %s" % metadata)

--- a/blinka/commands/update.py
+++ b/blinka/commands/update.py
@@ -42,7 +42,13 @@ def do_update(args):
     if args.firmware_version is None:
         metadata = blinka.board.get_version_metadata(board_id)
         logging.debug("metadata %s" % metadata)
-        target_firmware = next(version for version in metadata['versions'] if ('uf2' in version['extensions']) and (args.locale in version['languages']) and (args.stable == version['stable']))
+        try:
+            target_firmware = next(version for version in metadata['versions'] if ('uf2' in version['extensions']) and (args.locale in version['languages']) and (args.stable == version['stable']))
+        except:
+            message = "Could not find a stable firmware for %s %s." % (board_id, args.locale)
+            logging.critical(message)
+            logging.info("You can try the --unstable option and that might help.")
+            raise UpdateError(message)
         new_version = target_firmware['version']
         logging.debug("target_firmware %s" % target_firmware)
         logging.info("The latest available version is %s and you have version %s" % (new_version, version))


### PR DESCRIPTION
Some changes to handle issues I found with the MagTag:

1. Unknown board ID. I don't know if @FoamyGuy has a bigger plan to manage this. I added it by hand to the JSON file.
2. If there is no stable firmware version (there isn't for the MagTag), the update would explode. Now it complains. Then explodes.