### PR TITLE
Add changed MagTag board_id

### DIFF
--- a/blinka/board_id_map.json
+++ b/blinka/board_id_map.json
@@ -1,4 +1,5 @@
 {
+  "Adafruit MagTag with ESP32S2" : "adafruit_magtag_2.9_grayscale",
   "MagTag with ESP32S2" : "adafruit_magtag_2.9_grayscale",
   "Adafruit Feather M0 RFM69 with samd21g18": "feather_m0_rfm69",
   "Adafruit PyPortal Titano with samd51j20": "pyportal_titano",


### PR DESCRIPTION
For some reason the board_id changed for the MagTag. I left the old one there and added the new one.

@FoamyGuy did you have a more maintainable process you wanted to use here to get the board IDs?

Before:

```
🤓 Reading line from /media/blake/CIRCUITPY/boot_out.txt
🤓 boot_board = "Adafruit MagTag with ESP32S2"
🤓 board_id = None
🤓 Current CircuitPython version is 6.3.0
🤬 Could not automatically determine your board type, use the --board option
```

After:

```
🤓 Reading line from /media/blake/CIRCUITPY/boot_out.txt
🤓 boot_board = "Adafruit MagTag with ESP32S2"
🤓 board_id = adafruit_magtag_2.9_grayscale
🤓 Current CircuitPython version is 6.3.0
🤓 Fetching metadata from https://raw.githubusercontent.com/adafruit/circuitpython-org/master/_data/files.json
```