### PR TITLE
update readme and add requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ This is intended to provide various useful commands for maintaining CircuitPytho
 ## Running
 
 ```
-PS C:\Users\bcr00\Source\bcr\blinka-cli> python .\blinka.py --help
-usage: blinka.py [-h] [-v] [-l LOCALE] {backup,bossa,bootloader,update,sync,port,font} ...
+PS C:\Users\bcr00\Source\bcr\blinka-cli> python -m blinka --help
+usage: python -m blinka [-h] [-v] [-l LOCALE] {backup,bossa,bootloader,update,sync,port,font} ...
 
 Perform CircuitPython operations.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+dirsync
+freetype-py


### PR DESCRIPTION
Attempting to check out the latest changes I was unable to run with `python ./blinka.py` (I can find the error message if that is expected to work, perhaps I was in wrong directory or something).

I saw the comment about entry points and found that using `python -m blinka` to run commands does work for me. 

There were two pip requirements I had to install as well to get it running, I've added those to a requirements file.